### PR TITLE
[Backend] Visible name API

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_NAME_LENGTH = 32;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response, NextFunction } from 'express';
 import bcrypt from 'bcrypt';
+import { MAX_NAME_LENGTH } from '../constants';
 import { dbConn, doesUserExist, generateJWT, ValidateEmail } from '../utils';
 
 const jwtSecret = process.env.JWT_SECRET;
@@ -29,6 +30,9 @@ router.post('/register', async function(req: Request, res: Response, next: NextF
 
   if (await doesUserExist(username)) {
     res.status(409).json({ message: 'User already exists' });
+    return;
+  } else if (username.length > MAX_NAME_LENGTH) {
+    res.status(400).json({ message: "Username too long. 32 characters max." });
     return;
   }
 

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -36,8 +36,9 @@ router.post('/register', async function(req: Request, res: Response, next: NextF
   let salt = await bcrypt.genSalt(10);  
   let passwordHash = await bcrypt.hash(password, salt);
 
-  let sql = `INSERT INTO users (username, email, passwordHash) VALUES (?, ?, ?)`;
-  dbConn.run(sql, [username, email, passwordHash], (err: Error) => {
+  let sql = `INSERT INTO users (username, visibleName, email, passwordHash) VALUES (?, ?, ?, ?)`;
+  // Set username as visibleName on registration
+  dbConn.run(sql, [username, username, email, passwordHash], (err: Error) => {
     if (err) {
       console.error(err);
       res.status(500).json({ message: 'Error registering user' });

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response, NextFunction } from 'express';
+import { MAX_NAME_LENGTH } from '../constants';
 import { dbConn, getImageType, resizeImage, isAuthenticated } from '../utils';
 
 let router = express.Router();
@@ -107,7 +108,7 @@ router.delete('/picture', isAuthenticated, async function(req: Request, res: Res
  * Updates the visible name for the authenticated user.
  * @param visibleName the new visible name in the request body
  * @returns 200 if the visible name is updated successfully 
- * @returns 400 if the body is invalid
+ * @returns 400 if the body is invalid or the visible name is too long
  * @returns 500 if there is an error updating the visible name
  */
 router.put('/visibleName', isAuthenticated, async function(req: Request, res: Response, next: NextFunction) {
@@ -115,6 +116,9 @@ router.put('/visibleName', isAuthenticated, async function(req: Request, res: Re
   const visibleName = req.body.visibleName;
   if (!visibleName) {
     res.status(400).json({ message: "No name provided" });
+    return;
+  } else if (visibleName.length > MAX_NAME_LENGTH) {
+    res.status(400).json({ message: "Username too long. 32 characters max." });
     return;
   }
 

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -49,8 +49,6 @@ router.put('/picture', isAuthenticated, async function(req: Request, res: Respon
 /**
  * Retrieves a picture for a user.
  * @param username the username of the user
- * @returns 400 if no username is provided
- * @returns 404 if the user is not found, if the user has no profile picture
  * @returns 500 if there is an error retrieving the picture
  * @returns the picture with the correct content type if successful
  */
@@ -88,8 +86,6 @@ router.get('/picture', async function(req: Request, res: Response, next: NextFun
 /**
  * Deletes a picture for the authenticated user.
  * Data is sent as a JSON object in the request body.
- * @returns 400 if no username is provided
- * @returns 401 if the user is not authenticated
  * @returns 500 if there is an error deleting the picture
  * @returns 200 if the picture is deleted successfully
  */
@@ -104,6 +100,34 @@ router.delete('/picture', isAuthenticated, async function(req: Request, res: Res
     }
 
     res.status(200).json({ message: 'Picture deleted successfully' });
+  });
+});
+
+/**
+ * Updates the visible name for the authenticated user.
+ * @param visibleName the new visible name in the request body
+ * @returns 400 if the body is invalid
+ * @returns 500 if there is an error updating the visible name
+ * @returns 200 if the visible name is updated successfully 
+ */
+router.put('/visibleName', isAuthenticated, async function(req: Request, res: Response, next: NextFunction) {
+  // Get the visibleName from the request
+  const visibleName = req.body.visibleName;
+  if (!visibleName) {
+    res.status(400).json({ message: "No name provided" });
+    return;
+  }
+
+  // Update the visibleName in the database
+  const sql = `UPDATE users SET visibleName = ? WHERE username = ?`;
+  dbConn.run(sql, [visibleName, req.additionalInfo.jwtPayload.username], (err: Error) => {
+    if (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Error updating visible name' });
+      return;
+    }
+
+    res.status(200).json({ message: 'Visible name updated successfully' });
   });
 });
 

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -106,9 +106,9 @@ router.delete('/picture', isAuthenticated, async function(req: Request, res: Res
 /**
  * Updates the visible name for the authenticated user.
  * @param visibleName the new visible name in the request body
+ * @returns 200 if the visible name is updated successfully 
  * @returns 400 if the body is invalid
  * @returns 500 if there is an error updating the visible name
- * @returns 200 if the visible name is updated successfully 
  */
 router.put('/visibleName', isAuthenticated, async function(req: Request, res: Response, next: NextFunction) {
   // Get the visibleName from the request

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -131,4 +131,35 @@ router.put('/visibleName', isAuthenticated, async function(req: Request, res: Re
   });
 });
 
+/**
+ * Retrieves the visible name for a user.
+ * @param username the username of the user
+ * @returns 200 if the visible name is retrieved successfully
+ * @returns 400 if no username is provided
+ * @returns 404 if the user is not found
+ * @returns 500 if there is an error retrieving the visible name
+ */
+router.get('/visibleName', async function(req: Request, res: Response, next: NextFunction) {
+  const username = req.query.username;
+  if (!username) {
+    res.status(400).json({ message: "No 'username' provided" });
+    return;
+  }
+
+  const sql = `SELECT visibleName FROM users WHERE username = ?`;
+  dbConn.get(sql, [username], (err: Error, row: any) => {
+    if (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Error retrieving visible name' });
+      return;
+    }
+    if (!row) {
+      res.status(404).json({ message: 'User not found' });
+      return;
+    }
+
+    res.status(200).json({ visibleName: row.visibleName });
+  });
+});
+
 export default router;

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -9,7 +9,7 @@ dbConn.serialize(() => {
 });
 
 function createTable(db: Database) {
-	db.run(`CREATE TABLE IF NOT EXISTS users (username TEXT PRIMARY KEY, email TEXT, passwordHash TEXT, profilePic BLOB DEFAULT NULL)`);
+	db.run(`CREATE TABLE IF NOT EXISTS users (username TEXT PRIMARY KEY, visibleName TEXT, email TEXT, passwordHash TEXT, profilePic BLOB DEFAULT NULL)`);
 }
 
 export async function doesUserExist(username: string): Promise<boolean> {


### PR DESCRIPTION
Limits name and visibleName to 32 chars max.

Adds the following endpoints:
* **PUT** - `/profile/visibleName` - Expects a `visibleName` inside the body, which is set as the visible name of the authenticated user
* **GET** - `/profile/visibleName` - Expects a `username` as a URL query parameter. Returns the stored visible name